### PR TITLE
Add short-selling support for day strategy

### DIFF
--- a/executors/alpaca_day.py
+++ b/executors/alpaca_day.py
@@ -1,4 +1,4 @@
-# Genie_stocks_Top3_v0.py - Top 3 Strategy (30-Min Change, Price/Volume Filters)
+# Genie_stocks_Top3_v0.py - Top 20 Strategy (10 Long / 10 Short)
 # - Scans NYSE/NASDAQ based on 30-min % change.
 # - Filters by price ($1-$50) and 15-min volume (>300k).
 # - Uses previous close for initial price reference if needed.
@@ -67,7 +67,9 @@ TRADE_NOTIONAL_PER_STOCK = 5000
 JOB_INTERVAL_MINUTES = 2
 HOLD_TIME_LIMIT_MINUTES = 30
 EXIT_PRICE_FETCH_DELAY_SECONDS = 1.5
-MAX_OPEN_POSITIONS = 3
+MAX_LONG_POSITIONS = 10
+MAX_SHORT_POSITIONS = 10
+MAX_OPEN_POSITIONS = MAX_LONG_POSITIONS + MAX_SHORT_POSITIONS
 EXTENDED_HOURS_TRADING = True
 
 # --- Filtering Parameters ---
@@ -87,9 +89,13 @@ logging.basicConfig(
     ],
     encoding='utf-8'
 )
-logging.info(f"-------------------- BOT START (Top3_v0 - 30min Change) --------------------")
+logging.info(f"-------------------- BOT START (Top20_v0 - 30min Change) --------------------")
 logging.info(f"PAPER_TRADING: {PAPER_TRADING}")
-logging.info(f"Trade Notional: ${TRADE_NOTIONAL_PER_STOCK}, Max Positions: {MAX_OPEN_POSITIONS}, Hold Limit: {HOLD_TIME_LIMIT_MINUTES} min")
+logging.info(
+    f"Trade Notional: ${TRADE_NOTIONAL_PER_STOCK}, "
+    f"Max Long: {MAX_LONG_POSITIONS}, Max Short: {MAX_SHORT_POSITIONS}, "
+    f"Hold Limit: {HOLD_TIME_LIMIT_MINUTES} min"
+)
 logging.info(f"Job Interval: {JOB_INTERVAL_MINUTES} min, Extended Hours Data: {EXTENDED_HOURS_TRADING}")
 logging.info(f"Filters: Price ${MIN_PRICE_FILTER}-${MAX_PRICE_FILTER}, Min Volume ({VOLUME_LOOKBACK_MINUTES}min): {MIN_VOLUME_FILTER}, Ranking Lookback: {RANKING_LOOKBACK_MINUTES}min")
 logging.warning("Ensure you have an adequate Alpaca data plan (SIP recommended) for full NYSE/NASDAQ scanning.")
@@ -158,7 +164,11 @@ def execute_trade(symbol: str, side: OrderSide, qty: float = None, notional: flo
         elif side == OrderSide.SELL and qty is not None:
             order_data = MarketOrderRequest(symbol=symbol, qty=abs(float(qty)), side=side, time_in_force=TimeInForce.DAY)
             log_action = f"SELL {symbol} (Qty: {abs(float(qty))})"
-        else: raise ValueError("Invalid parameters for execute_trade: Need (notional for BUY) or (qty for SELL).")
+        elif side == OrderSide.SELL and notional is not None:
+            order_data = MarketOrderRequest(symbol=symbol, notional=notional, side=side, time_in_force=TimeInForce.DAY)
+            log_action = f"SELL {symbol} (Notional: ${notional})"
+        else:
+            raise ValueError("Invalid parameters for execute_trade: Need (notional for BUY) or (qty/notional for SELL).")
         logging.info(f"Attempting order: {log_action}")
         trade_order = rest_client.submit_order(order_data=order_data)
         logging.info(f"Order submitted for {log_action}. Order ID: {trade_order.id}")
@@ -352,13 +362,22 @@ def run_strategy_cycle():
         if not allow_run: return actions_by_user
     except Exception as e: logging.error(f"Market status check failed: {e}", exc_info=True); return actions_by_user
 
-    ranks = scan_market_30min_change() # Scan Market
-    if not ranks: logging.warning("Scan returned no ranks. Aborting cycle."); return actions_by_user
+    ranks = scan_market_30min_change()  # Scan Market
+    if not ranks:
+        logging.warning("Scan returned no ranks. Aborting cycle.")
+        return actions_by_user
 
-    current_top_performers = ranks[:MAX_OPEN_POSITIONS]
+    long_candidates = [r for r in ranks if r['change'] > 0][:MAX_LONG_POSITIONS]
+    short_candidates = sorted(
+        [r for r in ranks if r['change'] < 0], key=lambda x: x['change']
+    )[:MAX_SHORT_POSITIONS]
+
+    current_top_performers = long_candidates + short_candidates
     current_top_symbols = {r['symbol'] for r in current_top_performers}
     top_log_str = [f"{r['symbol']}({r['change']:.2f}%)" for r in current_top_performers]
-    logging.info(f"Current Top {MAX_OPEN_POSITIONS} (30min %): {', '.join(top_log_str)}")
+    logging.info(
+        f"Current Top {len(current_top_symbols)} (30min %): {', '.join(top_log_str)}"
+    )
 
     enabled_users = list(uid for uid, enabled in state.get("strategy_enabled", {}).items() if enabled)
     if not enabled_users: logging.info("No users enabled."); return actions_by_user
@@ -374,9 +393,17 @@ def run_strategy_cycle():
         user_actions = []
         try:
             logging.debug(f"Processing User ID: {user_id}")
-            open_trades_state = {t['symbol']: t for t in state.get("trades", []) if t.get("user") == user_id and t.get("status") == "open"}
+            open_trades_state = {
+                t['symbol']: t
+                for t in state.get("trades", [])
+                if t.get("user") == user_id and t.get("status") == "open"
+            }
             held_symbols_in_state = set(open_trades_state.keys())
-            logging.debug(f"User {user_id} Held (state): {held_symbols_in_state}")
+            held_long = {s for s, t in open_trades_state.items() if t.get("side") != "short"}
+            held_short = {s for s, t in open_trades_state.items() if t.get("side") == "short"}
+            logging.debug(
+                f"User {user_id} Held (long:{len(held_long)} short:{len(held_short)}): {held_symbols_in_state}"
+            )
 
             # Sync State
             mismatched = {s for s in held_symbols_in_state if s not in positions_map}
@@ -384,13 +411,13 @@ def run_strategy_cycle():
                 logging.warning(f"User {user_id} - Sync Discrepancy (State shows open, Alpaca doesn't): {mismatched}")
                 indices = [i for i, t in enumerate(state["trades"]) if t.get("user") == user_id and t.get("symbol") in mismatched and t.get("status") == "open"]
                 for idx in indices: state["trades"][idx].update({"status": "closed_orphan", "exit_time": datetime.now(timezone.utc).isoformat(), "exit_reason": "Orphan"})
-                open_trades_in_state = {k: v for k, v in open_trades_in_state.items() if k not in mismatched}
-                held_symbols_in_state = set(open_trades_in_state.keys())
+                open_trades_state = {k: v for k, v in open_trades_state.items() if k not in mismatched}
+                held_symbols_in_state = set(open_trades_state.keys())
 
             # Check Exits
             symbols_to_sell = set(); sell_reasons = {}; now_dt = datetime.now(timezone.utc)
             for symbol in held_symbols_in_state:
-                trade_info = open_trades_in_state.get(symbol); exit_reason = None
+                trade_info = open_trades_state.get(symbol); exit_reason = None
                 if not trade_info: continue
                 if symbol not in current_top_symbols: exit_reason = "Displaced (30min)"
                 elif trade_info.get('executed_at'):
@@ -404,12 +431,16 @@ def run_strategy_cycle():
                 logging.info(f"User {user_id} - Selling: {symbols_to_sell}")
                 sell_time = datetime.now(timezone.utc)
                 for symbol in symbols_to_sell:
-                    trade_info = open_trades_in_state.get(symbol); position = positions_map.get(symbol)
-                    if not trade_info or not position: logging.warning(f"Missing info for sell {symbol}"); continue
+                    trade_info = open_trades_state.get(symbol)
+                    position = positions_map.get(symbol)
+                    if not trade_info or not position:
+                        logging.warning(f"Missing info for sell {symbol}")
+                        continue
                     try:
                         qty = abs(float(position.qty))
                         if qty > 0:
-                            exit_id = execute_trade(symbol=symbol, side=OrderSide.SELL, qty=qty)
+                            exit_side = OrderSide.BUY if trade_info.get("side") == "short" else OrderSide.SELL
+                            exit_id = execute_trade(symbol=symbol, side=exit_side, qty=qty)
                             time.sleep(EXIT_PRICE_FETCH_DELAY_SECONDS); exit_price = None
                             try: req = StockLatestTradeRequest(symbol_or_symbols=symbol, feed='sip'); snap = data_client.get_stock_latest_trade(req); exit_price = snap[symbol].price if symbol in snap and snap[symbol].price > 0 else trade_info.get('entry_price')
                             except Exception as e: logging.error(f"Exit price fetch failed for {symbol}: {e}"); exit_price = trade_info.get('entry_price')
@@ -420,43 +451,125 @@ def run_strategy_cycle():
                             if idx != -1:
                                 entry_px = float(state["trades"][idx].get("entry_price", 0))
                                 state["trades"][idx].update({"status": "closed", "exit_price": exit_price, "exit_time": sell_time.isoformat(), "exit_id": exit_id, "exit_reason": sell_reasons.get(symbol)})
-                                if entry_px > 0 and exit_price > 0: profit = (exit_price - entry_px) * qty; pct = ((exit_price - entry_px) / entry_px) * 100
+                                if entry_px > 0 and exit_price > 0:
+                                    if trade_info.get("side") == "short":
+                                        profit = (entry_px - exit_price) * qty
+                                        pct = ((entry_px - exit_price) / entry_px) * 100
+                                    else:
+                                        profit = (exit_price - entry_px) * qty
+                                        pct = ((exit_price - entry_px) / entry_px) * 100
                                 pnl = {"user": user_id, "symbol": symbol, "profit": round(profit, 2), "pct_change": round(pct, 2), "time": sell_time.isoformat(), "entry_price": entry_px, "exit_price": exit_price, "entry_trade_id": trade_info.get("trade_id"), "exit_trade_id": exit_id, "exit_reason": sell_reasons.get(symbol)}
                                 state.setdefault("pnl", []).append(pnl)
-                                logging.info(f"User {user_id} - Closed {symbol}: PnL ${profit:.2f} ({pct:.2f}%) Reason: {sell_reasons.get(symbol)}")
+                                logging.info(
+                                    f"User {user_id} - Closed {symbol}: PnL ${profit:.2f} ({pct:.2f}%) Reason: {sell_reasons.get(symbol)}"
+                                )
                                 user_actions.append({"action": "SELL", "symbol": symbol, "reason": sell_reasons.get(symbol), "price": exit_price, "pnl": round(profit, 2), "pct": round(pct, 2)})
                             else: logging.error(f"State update failed for closed {symbol}")
                         else: logging.warning(f"Alpaca position qty for {symbol} was 0. Marking closed."); idx = next((i for i, t in enumerate(state["trades"]) if t.get("user") == user_id and str(t.get("trade_id")) == str(trade_info.get("trade_id")) and t.get("status") == "open"), -1); state["trades"][idx].update({"status": "closed_zero_qty", "exit_reason": "Zero quantity found"}) if idx != -1 else None
                     except APIError as e: logging.error(f"API error selling {symbol}: {e}"); idx = next((i for i, t in enumerate(state["trades"]) if t.get("user") == user_id and str(t.get("trade_id")) == str(trade_info.get("trade_id")) and t.get("status") == "open"), -1); state["trades"][idx].update({"status": "closed_orphan", "exit_reason": f"Sell failed ({e.status_code})"}) if idx != -1 and e.status_code == 404 else None
                     except Exception as e: logging.error(f"Generic error closing {symbol}: {e}", exc_info=True)
 
-            # Execute Buys
-            open_trades_state = {t['symbol']: t for t in state.get("trades", []) if t.get("user") == user_id and t.get("status") == "open"}
-            held_symbols = set(open_trades_state.keys()); num_held = len(held_symbols); num_can_buy = MAX_OPEN_POSITIONS - num_held
-            symbols_to_buy = current_top_symbols - held_symbols
-            if symbols_to_buy and num_can_buy > 0:
-                logging.info(f"User {user_id} - Evaluating buys ({num_can_buy} slots): {symbols_to_buy}")
-                buy_count = 0; buy_time = datetime.now(timezone.utc)
-                for rank in current_top_performers:
+            # Execute Buys (Long & Short)
+            open_trades_state = {
+                t['symbol']: t
+                for t in state.get("trades", [])
+                if t.get("user") == user_id and t.get("status") == "open"
+            }
+            held_long = {s for s, t in open_trades_state.items() if t.get("side") != "short"}
+            held_short = {s for s, t in open_trades_state.items() if t.get("side") == "short"}
+            num_can_long = MAX_LONG_POSITIONS - len(held_long)
+            num_can_short = MAX_SHORT_POSITIONS - len(held_short)
+
+            symbols_long = {r['symbol'] for r in long_candidates} - held_long
+            symbols_short = {r['symbol'] for r in short_candidates} - held_short
+
+            if (symbols_long and num_can_long > 0) or (symbols_short and num_can_short > 0):
+                logging.info(
+                    f"User {user_id} - Evaluating entries L{num_can_long} S{num_can_short}: {symbols_long | symbols_short}"
+                )
+                buy_time = datetime.now(timezone.utc)
+
+                for rank in long_candidates:
                     symbol = rank['symbol']
-                    if symbol in symbols_to_buy and buy_count < num_can_buy:
-                        if symbol in held_symbols: continue # Should not happen
+                    if symbol in symbols_long and num_can_long > 0:
+                        if symbol in held_long:
+                            continue
                         try:
                             price = rank['price']
-                            if price <= 0: continue
+                            if price <= 0:
+                                continue
                             logging.info(f"User {user_id} - Executing BUY {symbol} @ ~${price:.2f}")
                             order_id = execute_trade(symbol=symbol, side=OrderSide.BUY, notional=TRADE_NOTIONAL_PER_STOCK)
-                            new = {"user": user_id, "symbol": symbol, "notional": TRADE_NOTIONAL_PER_STOCK, "side": "buy", "executed_at": buy_time.isoformat(), "entry_price": price, "trade_id": order_id, "status": "open"}
+                            new = {
+                                "user": user_id,
+                                "symbol": symbol,
+                                "notional": TRADE_NOTIONAL_PER_STOCK,
+                                "side": "long",
+                                "executed_at": buy_time.isoformat(),
+                                "entry_price": price,
+                                "trade_id": order_id,
+                                "status": "open",
+                            }
                             state.setdefault("trades", []).append(new)
-                            buy_count += 1; held_symbols.add(symbol) # Update local view
-                            logging.info(f"User {user_id} - Entered {symbol} (#{buy_count}/{num_can_buy}) Order ID: {order_id}")
+                            num_can_long -= 1
+                            held_long.add(symbol)
+                            logging.info(
+                                f"User {user_id} - Entered {symbol} Order ID: {order_id}"
+                            )
                             user_actions.append({"action": "BUY", "symbol": symbol, "price": price})
                         except APIError as e:
-                            logging.error(f"API error buying {symbol}: {e}", exc_info=False); reason = f"API Error {e.status_code}"
-                            if e.status_code == 403: reason = "Forbidden/Funds"; break
-                            elif e.status_code == 422: reason = "Not Tradable"
+                            logging.error(f"API error buying {symbol}: {e}", exc_info=False)
+                            reason = f"API Error {e.status_code}"
+                            if e.status_code == 403:
+                                reason = "Forbidden/Funds"
+                                break
+                            elif e.status_code == 422:
+                                reason = "Not Tradable"
                             user_actions.append({"action": "BUY_FAIL", "symbol": symbol, "reason": reason})
-                        except Exception as e: logging.error(f"Failed buy execution for {symbol}: {e}", exc_info=True); user_actions.append({"action": "BUY_FAIL", "symbol": symbol, "reason": "Exec Error"})
+                        except Exception as e:
+                            logging.error(f"Failed buy execution for {symbol}: {e}", exc_info=True)
+                            user_actions.append({"action": "BUY_FAIL", "symbol": symbol, "reason": "Exec Error"})
+
+                for rank in short_candidates:
+                    symbol = rank['symbol']
+                    if symbol in symbols_short and num_can_short > 0:
+                        if symbol in held_short:
+                            continue
+                        try:
+                            price = rank['price']
+                            if price <= 0:
+                                continue
+                            logging.info(f"User {user_id} - Executing SHORT {symbol} @ ~${price:.2f}")
+                            order_id = execute_trade(symbol=symbol, side=OrderSide.SELL, notional=TRADE_NOTIONAL_PER_STOCK)
+                            new = {
+                                "user": user_id,
+                                "symbol": symbol,
+                                "notional": TRADE_NOTIONAL_PER_STOCK,
+                                "side": "short",
+                                "executed_at": buy_time.isoformat(),
+                                "entry_price": price,
+                                "trade_id": order_id,
+                                "status": "open",
+                            }
+                            state.setdefault("trades", []).append(new)
+                            num_can_short -= 1
+                            held_short.add(symbol)
+                            logging.info(
+                                f"User {user_id} - Entered SHORT {symbol} Order ID: {order_id}"
+                            )
+                            user_actions.append({"action": "SHORT", "symbol": symbol, "price": price})
+                        except APIError as e:
+                            logging.error(f"API error shorting {symbol}: {e}", exc_info=False)
+                            reason = f"API Error {e.status_code}"
+                            if e.status_code == 403:
+                                reason = "Forbidden/Funds"
+                                break
+                            elif e.status_code == 422:
+                                reason = "Not Tradable"
+                            user_actions.append({"action": "BUY_FAIL", "symbol": symbol, "reason": reason})
+                        except Exception as e:
+                            logging.error(f"Failed short execution for {symbol}: {e}", exc_info=True)
+                            user_actions.append({"action": "BUY_FAIL", "symbol": symbol, "reason": "Exec Error"})
         except Exception as loop_err: logging.error(f"Error in user loop {user_id}: {loop_err}", exc_info=True)
         if user_actions: actions_by_user[user_id] = user_actions
 
@@ -486,15 +599,33 @@ async def top_3_strategy_job_callback(context: ContextTypes.DEFAULT_TYPE):
                 message = "❓ Unknown action"; symbol = action.get("symbol", "N/A")
                 try:
                     a_type = action.get("action")
-                    if a_type == "BUY": message = f"⬆️ **Entered {symbol}** (Top3)\nApprox Entry: ${action.get('price', 0):.2f}"
-                    elif a_type == "SELL": message = f"⬇️ **Exited {symbol}** ({action.get('reason', 'N/A')})\nApprox Exit: ${action.get('price', 0):.2f}\nApprox PnL: ${action.get('pnl', 0):+.2f} ({action.get('pct', 0):+.2f}%)"
-                    elif a_type == "BUY_FAIL": message = f"⚠️ Failed to buy {symbol}: {action.get('reason', 'Unknown')}"
+                    if a_type == "BUY":
+                        message = f"⬆️ **Entered {symbol}** (Top20)\nApprox Entry: ${action.get('price', 0):.2f}"
+                    elif a_type == "SHORT":
+                        message = f"⬇️ **Shorted {symbol}** (Top20)\nApprox Entry: ${action.get('price', 0):.2f}"
+                    elif a_type == "SELL":
+                        message = (
+                            f"⬇️ **Exited {symbol}** ({action.get('reason', 'N/A')})\n"
+                            f"Approx Exit: ${action.get('price', 0):.2f}\n"
+                            f"Approx PnL: ${action.get('pnl', 0):+.2f} ({action.get('pct', 0):+.2f}%)"
+                        )
+                    elif a_type == "BUY_FAIL":
+                        message = f"⚠️ Failed to buy {symbol}: {action.get('reason', 'Unknown')}"
                     await bot.send_message(chat_id=user_id, text=message, parse_mode=ParseMode.MARKDOWN)
                     logging.info(f"Sent notification to {user_id}: {message.splitlines()[0]}")
                 except telegram.error.BadRequest as tg_err:
-                     if "chat not found" in str(tg_err).lower(): logging.error(f"Chat not found {user_id}. Disabling."); async with state_lock: state.setdefault("strategy_enabled", {})[user_id] = False; await asyncio.to_thread(save_state, state)
-                     else: logging.error(f"TG BadRequest {user_id}: {tg_err}")
-                except telegram.error.Forbidden as tg_err: logging.error(f"TG Forbidden {user_id}. Disabling."); async with state_lock: state.setdefault("strategy_enabled", {})[user_id] = False; await asyncio.to_thread(save_state, state)
+                    if "chat not found" in str(tg_err).lower():
+                        logging.error(f"Chat not found {user_id}. Disabling.")
+                        async with state_lock:
+                            state.setdefault("strategy_enabled", {})[user_id] = False
+                            await asyncio.to_thread(save_state, state)
+                    else:
+                        logging.error(f"TG BadRequest {user_id}: {tg_err}")
+                except telegram.error.Forbidden as tg_err:
+                    logging.error(f"TG Forbidden {user_id}. Disabling.")
+                    async with state_lock:
+                        state.setdefault("strategy_enabled", {})[user_id] = False
+                        await asyncio.to_thread(save_state, state)
                 except Exception as tg_err: logging.error(f"TG send error {user_id}: {tg_err}", exc_info=True)
     else: logging.debug("No actions generated.")
     logging.debug("JobQueue callback finished.")
@@ -545,7 +676,11 @@ async def handle_pnl(update: Update, context: ContextTypes.DEFAULT_TYPE):
     limit = 10; summary = f"📈 **Closed PnL (Last {min(limit, trades)}/{trades})**\n\n"
     for t in reversed(pnl_recs[-limit:]):
         sym = t.get('symbol', '?'); p = t.get('profit', 0); pct = t.get('pct_change', 0); r = t.get('exit_reason', 'N/A'); ts = "N/A"
-        if t.get("time"): try: ts = isoparse(t["time"]).strftime('%m-%d %H:%M'); except: pass
+        if t.get("time"):
+            try:
+                ts = isoparse(t["time"]).strftime('%m-%d %H:%M')
+            except Exception:
+                pass
         summary += f" - **{sym}**: ${p:+.2f} ({pct:+.2f}%) at {ts} _({r})_\n"
     summary += f"\n💰 **Total Realized: ${profit:.2f}** | Win Rate: {win_rate:.1f}% ({wins}W/{losses}L)"
     await update.message.reply_text(summary, parse_mode=ParseMode.MARKDOWN)
@@ -601,67 +736,3 @@ if __name__ == "__main__":
         logging.info("Attempting final state save...")
         save_state(state)
         logging.info("-------------------- BOT END ----------------------")
-```
-
-**Test Script Update:**
-(Updating the `alpaca_test_script` immersive block to use `get_all_assets`)
-
-
-```python
-# test_alpaca.py - Minimal script to test asset fetching
-
-import os
-import logging
-from dotenv import load_dotenv
-from alpaca.trading.client import TradingClient
-from alpaca.trading.enums import AssetStatus, AssetClass, AssetExchange
-from alpaca.trading.requests import GetAssetsRequest # Import request model
-import traceback
-
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
-
-load_dotenv()
-ALPACA_API_KEY = os.getenv("ALPACA_API_KEY")
-ALPACA_SECRET_KEY = os.getenv("ALPACA_SECRET_KEY")
-
-if not ALPACA_API_KEY or not ALPACA_SECRET_KEY:
-    logging.error("API Keys not found in .env file!")
-    exit()
-else:
-    logging.info(f"API Key loaded: {ALPACA_API_KEY[:5]}...")
-
-try:
-    logging.info("Initializing TradingClient...")
-    client = TradingClient(ALPACA_API_KEY, ALPACA_SECRET_KEY, paper=True)
-    logging.info(f"Client Type: {type(client)}")
-
-    # Check if the method exists
-    has_get_all_assets = hasattr(client, 'get_all_assets')
-    logging.info(f"Client has 'get_all_assets' method: {has_get_all_assets}")
-
-    if not has_get_all_assets:
-         logging.error("FATAL: client object does not have 'get_all_assets' method!")
-         exit()
-
-    # Try calling get_all_assets (which worked based on user logs)
-    logging.info("Attempting client.get_all_assets for NASDAQ...")
-    search_params = GetAssetsRequest(
-        asset_class=AssetClass.US_EQUITY,
-        status=AssetStatus.ACTIVE,
-        exchange=AssetExchange.NASDAQ # Pass Enum directly if get_all_assets accepts it
-    )
-    assets = client.get_all_assets(search_params)
-    logging.info(f"SUCCESS: Fetched {len(assets)} NASDAQ assets using get_all_assets.")
-
-    # Print first 5 assets for verification
-    for i, asset in enumerate(assets[:5]):
-        logging.info(f"Asset {i+1}: {asset.symbol} - {asset.name}")
-
-
-except AttributeError as ae:
-    logging.critical(f"AttributeError during test: {ae}")
-    traceback.print_exc() # Print full traceback for AttributeError
-except Exception as e:
-    logging.error(f"An unexpected error occurred: {e}")
-    traceback.print_exc() # Print full traceback for other errors
-


### PR DESCRIPTION
## Summary
- update day strategy to trade up to 20 symbols (10 long, 10 short)
- adjust logs and parameters for new limits
- implement short entry/exit logic
- clean up leftover code and ensure script compiles

## Testing
- `python -m py_compile executors/alpaca_day.py`